### PR TITLE
Fix invalid bulk syncs

### DIFF
--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -67,7 +67,7 @@ Job.prototype.info = function(callback) {
   if (!this._jobInfo) {
     this._jobInfo = this.check();
   } else if (self.options.pkChunking) {
-    this._jobInfo.then((info) => {
+    this._jobInfo.then(function(info) {
       if (info.numberBatchesTotal !== '0' && info.numberBatchesTotal === info.numberBatchesCompleted) {
         self._jobInfo = Promise.resolve(info);
       // This means all batches failed.

--- a/lib/api/bulk.js
+++ b/lib/api/bulk.js
@@ -68,12 +68,15 @@ Job.prototype.info = function(callback) {
     this._jobInfo = this.check();
   } else if (self.options.pkChunking) {
     this._jobInfo.then((info) => {
-       if (info.numberBatchesTotal !== '0' && info.numberBatchesTotal === info.numberBatchesCompleted) {
+      if (info.numberBatchesTotal !== '0' && info.numberBatchesTotal === info.numberBatchesCompleted) {
         self._jobInfo = Promise.resolve(info);
-       } else {
+      // This means all batches failed.
+      } else if (info.numberBatchesTotal !== '0' && info.numberBatchesTotal === info.numberBatchesFailed) {
+        self._jobInfo = Promise.resolve(info);
+      } else {
         self._jobInfo = self.check();
-       }
-       return self._jobInfo.thenCall(callback);
+      }
+      return self._jobInfo.thenCall(callback);
     })
   }
 
@@ -631,6 +634,7 @@ Batch.prototype.poll = function(interval, timeout) {
     job.info().then(function(jobInfo) {
       self.check(function(err, res) {
         const batchesComplete = jobInfo.numberBatchesTotal !== '0' && jobInfo.numberBatchesTotal === jobInfo.numberBatchesCompleted;
+        const allBatchesFailed = jobInfo.numberBatchesTotal !== '0' && jobInfo.numberBatchesTotal === jobInfo.numberBatchesFailed;
         if (err) {
           self.emit('error', err);
         } else {
@@ -646,6 +650,9 @@ Batch.prototype.poll = function(interval, timeout) {
             job.retrieveBatches().then((results) => {
               self.emit('response', results);
             });
+          // Indicates a completely invalid query
+          } else if (res.state === "NotProcessed" && allBatchesFailed) {
+            self.emit('error', new Error('All batches failed') );
           } else {
             self.emit('progress', res);
             setTimeout(poll, interval);

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "envify": "^3.4.0",
     "espower-loader": "^1.0.0",
     "espowerify": "^1.0.0",
-    "gulp": "gulpjs/gulp#4.0",
+    "gulp": "^4.0.2",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.3",


### PR DESCRIPTION
Without this check, it's possible to infinitely loop on completley
failed queries (i.e. invalid syntax). This adds a check for completely
failed queries and emits an error in response.

This is based on this PR https://github.com/bigpictureio/jsforce/pull/2 from bigpictureio (they gave us some details here: https://mail.mixmax.com/m/XJ6r8D7EfjyWxl57f)