### PR TITLE
callback with an error when the response is falsy instead of throwing…

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -229,6 +229,7 @@ Connection.prototype.initialize = function(options) {
 function oauthRefreshFn(conn, callback) {
   conn.oauth2.refreshToken(conn.refreshToken, function(err, res) {
     if (err) { return callback(err); }
+    if (!res) { return callback(new Error('jsforce: oauthRefreshFn: result cannot be falsy')); }
     var userInfo = parseIdUrl(res.id);
     conn.initialize({
       instanceUrl : res.instance_url,


### PR DESCRIPTION
Instead of throwing an exception in the runtime callback with an error so we don't crash the entire process from connection.js#oauthRefreshFn.