### PR TITLE
fix: support multiple conditions per field (AUTO-176)

### DIFF
--- a/lib/soql-builder.js
+++ b/lib/soql-builder.js
@@ -124,21 +124,23 @@ var opMap = {
 
 /** @private **/
 function createFieldExpression(field, value) {
-  var op = "$eq";
-
   // Assume the `$in` operator if value is an array and none was supplied.
-  if (_.isArray(value)) { op = "$in"; }
+  if (_.isArray(value)) {
+    return createOpExpression(field, "$in", value);
+  }
   // Otherwise, if an object was passed then process the supplied ops.
   else if (_.isObject(value)) {
-    var _value;
-    for (var k in value) {
-      if (k[0] === "$") {
-        op = k;
-        value = value[k];
-        break;
-      }
-    }
+    var expressions = _.map(value, function (v, k) {
+      if (k[0] === "$") return createOpExpression(field, k, v);
+    });
+    return expressions.join(' AND ');
   }
+  // If the value is a scalar, it's an equality condition.
+  else return createOpExpression(field, "$eq", value);
+}
+
+/** @private **/
+function createOpExpression(field, op, value) {
   var sfop = opMap[op];
   if (!sfop || _.isUndefined(value)) { return null; }
   var valueExpr = createValueExpression(value);

--- a/test/soql-builder.test.js
+++ b/test/soql-builder.test.js
@@ -30,6 +30,23 @@ describe("soql-builder", function() {
     });
   });
 
+  describe("Query with multiple conditions on a single field", function() {
+    var soql = SOQLBuilder.createSOQL({
+      fields: [ "Id" ],
+      table: "Opportunity",
+      conditions: { CloseDate: { $gte: '2020-02-25', $lt: '2020-02-26' } },
+      limit : 10,
+      offset : 20
+    });
+
+    it("should include all conditions", function() {
+      assert.ok(soql ===
+        "SELECT Id FROM Opportunity " +
+        "WHERE CloseDate >= '2020-02-25' AND CloseDate < '2020-02-26' "+
+        "LIMIT 10 OFFSET 20"
+      );
+    })
+  });
   /**
    *
    */


### PR DESCRIPTION
## Changes

Support multiple conditions in a single field, as in `{ "Date": {  "$gte": "2020-02-24", "$lt": "2020-02-25" } }`.

## Testing

* Added unit tests
* Tested with [this PR](https://github.com/mixmaxhq/rule-distribution/pull/103) (see [this comment](https://github.com/mixmaxhq/rule-distribution/pull/103/files#r383846616)).

## Notes

I checked this is not resolved in the parent repo (jsforce/jsforce).