### PR TITLE
chore: log network errors only when debug [ROCKET-153]

### DIFF
--- a/lib/http-api.js
+++ b/lib/http-api.js
@@ -105,7 +105,7 @@ HttpApi.prototype.request = function(request, callback) {
     return self.getResponseBody(response);
   }, function(err) {
     onComplete();
-    logger.error(err);
+    logger.debug("<request> error = " + err);
     throw err;
   })
   .thenCall(callback);


### PR DESCRIPTION
Jira: [ROCKET-153](https://mixmaxhq.atlassian.net/browse/ROCKET-153)

Log from this PR was unstructured and logged on every occurrence, so it lead to confusion when I though from CloudWatch logs that this error is unhandled and interrupts the main process.
![image](https://user-images.githubusercontent.com/15381780/189144045-17008e42-7af1-4014-8daa-7df8a706e61c.png)
Moved this to debug level since we throw it anyway and handle on top level.