### PR TITLE
fix: don't throw `request` exception if promise is already resolved

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -78,16 +78,55 @@ var Transport = module.exports = function() {};
 Transport.prototype.httpRequest = function(params, callback) {
   var deferred = Promise.defer();
   var req;
+  var didPromiseFinished = false;
   var httpRequest = this._getHttpRequestModule();
   var createRequest = function() {
     if (!req) {
       req = httpRequest(params, function(err, response) {
+        didPromiseFinished = true;
         if (err) {
           deferred.reject(err);
         } else {
           deferred.resolve(response);
         }
       });
+      
+      if (req.catch) {
+        /**
+         * If req.catch exists, then it means that the service that is running jsforce probably has `request-promise` in one of
+         * its forms. This means that a code similar to this one (1) will run and replace all imports of `request` from the
+         * vanilla one (that this repo expects) to the "promisified" one. So if that is the case, we need to handle the `.catch`
+         * of the promise, for the reasons described below.
+         * 
+         * (1) — https://github.com/request/promise-core#usage-for-request234
+         */
+        req.catch((ex) => {
+          /**
+           * We use `request` as the default HttpRequestModule for this library. The way we use `request` (callback) implies that
+           * we will handle success, and failures, inside the callback via the resolve/reject functions from the Promise.defer.
+           * 
+           * This is cool, but it can happen that the vanilla `request` get replaced by the `request-promise` on the service that
+           * is running `jsforce`. If that's the case, we run into problems.
+           * 
+           * Because of a (questionable) design decision on request-promise-core, we will **always** call the `callback` passing
+           * the result of the request (1). Then, if the request managed to not be a 2xx, request-promise-core will `reject` (2),
+           * bubbling up the exception to the `promise-catch` above (or throw `unhandledPromiseRejection`, if none is present).
+           * Ultimately, if the callback fails for some reason, the lib will throw (3).
+           * 
+           * Since we pass a callback _and_ we `resolve/reject` from inside this callback, letting the promise go, when request-promise-core
+           * reject the main promise after a non 2xx we end up having an unhandledPromiseRejection, which can be problematic, since
+           * the caller have no clear way to handle this rejection, letting it bubble up and kill the service.
+           * 
+           * Because of all the above, we should only `throw` this when the promise was not able to be resolved or rejected from
+           * inside the `callback` that we fed to `request`.
+           * 
+           * (1) — https://github.com/request/promise-core/blob/master/lib/plumbing.js#L74
+           * (2) — https://github.com/request/promise-core/blob/master/lib/plumbing.js#L83
+           * (3) — https://github.com/request/promise-core/blob/master/lib/plumbing.js#L129
+           */
+          if (!didPromiseFinished) throw ex;
+        });
+      }
     }
     return req;
   };


### PR DESCRIPTION
#### Changes Made
* Not throwing `request`'s exception if the promise is already resolved inside of the callback we send to `request`.

We use `request` as the default HttpRequestModule for this library. The way we use `request` (callback) implies that we will handle success, and failures, inside the callback via the resolve/reject functions from the `Promise.defer`.

This is cool, but it can happen that the vanilla `request` [get replaced](https://github.com/request/promise-core#usage-for-request234) by the `request-promise` on the service that is running `jsforce`. If that's the case, we run into problems.

Because of a (questionable) design decision on `request-promise-core`, we will **always** call the `callback` passing the result of the request (1). Then, if the request managed to not be a 2xx, request-promise-core will `reject` (2), bubbling up the exception to the `promise-catch` above (or throw `unhandledPromiseRejection`, if none is present). Ultimately, if the callback fails for some reason, the lib will throw (3).

Since we pass a callback _and_ we `resolve/reject` from inside this callback, letting the promise go, when `request-promise-core` reject the main promise after a non 2xx we end up having an `unhandledPromiseRejection`, which can be problematic, since the caller has no clear way to handle this rejection, letting it bubble up and _(possibly)_ kill the service.

Because of all the above, we should only `throw` this when the promise was not able to be resolved or rejected from inside the `callback` that we fed to `request`.

(1) — https://github.com/request/promise-core/blob/master/lib/plumbing.js#L74
(2) — https://github.com/request/promise-core/blob/master/lib/plumbing.js#L83
(3) — https://github.com/request/promise-core/blob/master/lib/plumbing.js#L129

#### Potential Risks
That we incorrectly swallow some exceptions that should be raised.
[the above is still under assessment. I believe this will not be a problem. `jsforce` code was designed to work with the value resolved/rejected from inside of the `callback` we send to `request`, literally treating the `request`'s rejection as `unhandledPromiseRejection`.]

#### Test Plan
_(this repo is public, but it is really used mainly by MM, so if you are not a Mixmaxer and is reading this, disregard the below test plan as it may not make a lot of sense to you — read it as: a bunch of regression testing that will try to assess that `jsforce` is behaving the same in various situations)_

- [x] Go into `service-salesforce` and replace vanilla `jsforce` with the one that contains the fix -> Restart all salesforce services
	- [x] It is cool to do this step first, so that `salesforce-api` will already have the fix, so we can assert that it is working properly while performing the below tests (that may require the `api`).
- [x] Go into `App` and replace vanilla `jsforce` with the one that contains the fix
	- [x] Disconnect and reconnect to Salesforce at the individual level (this will create a replica connection through the `users` oAuth implementation and reach to SFDC Directly)
	- [x] Reconnect the Sync-User (this will create a replica connection through the `users` oAuth implementation and reach to SFDC Directly)
	- [x] Create a Task with the Sync-to-Salesforce on — Assert that the Salesforce counterpart will be created with no issues
	- [x] Edit a Task that has a Salesforce counterpart — Assert that the Salesforce counterpart will be edited with no issues
	- [x] Delete a Task that has a Salesforce counterpart — Assert that the Salesforce counterpart will be deleted with no issues
	- [x] Create a Task with a Salesforce counterpart, Delete the counterpart on Salesforce but not on MM, then try to delete the task on MM Task Dashboard — Assert that the task will be deleted with no issues (previously, this used to throw the "oops" modal because of the `unhandledPromiseRejection`)
	- [x] Create a rule with a Salesforce trigger (e.g Contact Created)
		- [x] Make sure that it is possible to correctly manage the rule-filters for it
	- [x] Create a rule with a Salesforce action (e.g Edit Contact)
	- [x] Create a sequence -> Add recipients to sequence that came from SFDC
	- [x] Create a new Template -> Insert SFDC Variables on the template
		- [x] Deliver an email with the given template, check if the variables will be populated
	- [x] Access that the `settings/admin/integrations` is loading correctly
		- [x] Assert that API Limits is loading and is functional
		- [x] Assert that Activity Logging is loading and is functional
		- [x] Assert that the package instalation info is loading and accurate
		- [x] Assert that Sync Conditions is loading and is functional
		- [x] Assert that Custom Objects Setup is loading and is functional
		- [x] Assert that the RTS token refresh is working as expected
		- [x] Assert that the Insights Package checking is working as expected
	- [x] Opening a contact on the sidebar
- [x] Rules
	- [x] Trigger the SFDC rule created above and assert that trigger, filter and actions are working as expected
- [x] Activity-Sync
	- [x] Deliver an email via M2 to a Salesforce `contact` -> Assert that the `send` activity will be created on SFDC
		- [x] Open the above email -> Assert that the `open` event will be created on SFDC
	- [x] _(The above should assess that the `consumers` and the `crons` from `activity-sync` are green)_
- [x] Incremental Syncs
	- [x] Perform changes on SFDC to a set of objects -> Trigger one Incremental Sync -> Assert that the changes are reflected on our replica
- [x] Real Time Sync
	- [x] Setup RTS properly
	- [x] Perform changes on SFDC to a set of objects -> Assert that the changes are reflected on our replica ASAP

#### Release Plan
Merge, and cut a new version of the package.